### PR TITLE
Fixed process listing to handle long usernames

### DIFF
--- a/sbin/reaver
+++ b/sbin/reaver
@@ -160,7 +160,7 @@ if ( $safelist ne "" )
 
 # find all the target pids
 my @pids=();
-open(PS,"ps -A -o pid,state,uid,user,command |");
+open(PS,"ps -A -o pid,state,uid,user=WIDE-USER-COLUMN,command |");
 # snarf the 1st line
 <PS>;
 print "Stray processes:\n" if $verbose_mode;


### PR DESCRIPTION
Reaver kills processes of users with usernames greater than 8 characters, because ps doesn't show their username (just their UID). 

The problem is with the command `ps -A -o pid,state,uid,user,command`

According to the ps man page:

>    If the length of the username is greater than the length of the display column, the numeric user ID is displayed instead.

What's happening is that reaver is requesting a list of processes and expecting to get the username for each process, but when users have a username greater than 8 characters, the UID is displayed instead. These don't match against the username, and so reaver assumes they aren't owned by the user, and kills them.

The solution is to explicitly request that the user column is "wide" (i.e. will widen automatically), like so: `ps -A -o pid,state,uid,user=WIDE-USER-COLUMN,command`
